### PR TITLE
CoC näher an den Vereinszweck bzw. die Statuten anpassen

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,7 +1,7 @@
 ﻿Code of Conduct (Hausordnung)
 =============================
 
-Das Metalab ist eine inklusive Gemeinschaft, wo alle unabhängig ihres Alters, ihrer Herkunft, ihres Geschlechts, ihrer Sexualität, ihres Einkommens oder ihrer Religion willkommen sind, um sich in einer respektvollen, toleranten und ermutigenden Umgebung zu Bilden und sich gegenseitig auf dem Gebiet der Kunst, Wissenschaft und Forschung zu fördern. Wir wollen, dass alle Anwesenden eine angenehme und erfüllende Zeit im Metalab verbringen. Daher sind alle Anwesenden dazu angehalten, freundlich und respektvoll miteinander umzugehen.
+Das Metalab ist eine inklusive Gemeinschaft, wo alle unabhängig ihres Alters, ihrer Herkunft, ihres Geschlechts, ihrer Sexualität, ihres Einkommens oder ihrer Religion willkommen sind, um sich in einer respektvollen, toleranten und ermutigenden Umgebung zu bilden und sich gegenseitig auf dem Gebiet der Kunst, Wissenschaft und Forschung zu fördern. Wir wollen, dass alle Anwesenden eine angenehme und erfüllende Zeit im Metalab verbringen. Daher sind alle Anwesenden dazu angehalten, freundlich und respektvoll miteinander umzugehen.
 
 Alle Mitglieder sind gleichberechtigt, und dürfen das Metalab zum Erschaffen neuer Dinge nutzen, sofern sie dabei niemanden einschränken. Der folgende Code of Conduct hält fest, was in den Räumlichkeiten des Metalabs bzw. anderen Treffen im Rahmen des Vereins Metalab von allen Anwesenden erwartet wird.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,7 +1,7 @@
-Code of Conduct (Hausordnung)
+﻿Code of Conduct (Hausordnung)
 =============================
 
-Das Metalab ist eine inklusive Gemeinschaft, wo alle unabhängig ihres Alters, ihrer Herkunft, ihres Geschlechts, ihrer Sexualität, ihres Einkommens oder ihrer Religion willkommen sind, um in einer respektvollen, toleranten und ermutigenden Umgebung über Technologie zu diskutieren und zu lernen. Wir wollen, dass alle Anwesenden eine angenehme und erfüllende Zeit im Metalab verbringen. Daher sind alle Anwesenden dazu angehalten, freundlich und respektvoll miteinander umzugehen.
+Das Metalab ist eine inklusive Gemeinschaft, wo alle unabhängig ihres Alters, ihrer Herkunft, ihres Geschlechts, ihrer Sexualität, ihres Einkommens oder ihrer Religion willkommen sind, um sich in einer respektvollen, toleranten und ermutigenden Umgebung zu Bilden und sich gegenseitig auf dem Gebiet der Kunst, Wissenschaft und Forschung zu fördern. Wir wollen, dass alle Anwesenden eine angenehme und erfüllende Zeit im Metalab verbringen. Daher sind alle Anwesenden dazu angehalten, freundlich und respektvoll miteinander umzugehen.
 
 Alle Mitglieder sind gleichberechtigt, und dürfen das Metalab zum Erschaffen neuer Dinge nutzen, sofern sie dabei niemanden einschränken. Der folgende Code of Conduct hält fest, was in den Räumlichkeiten des Metalabs bzw. anderen Treffen im Rahmen des Vereins Metalab von allen Anwesenden erwartet wird.
 


### PR DESCRIPTION
Hab den Text umgeschrieben, damit er sich mehr an den Vereinsstatuten §1 - 1 und §2 - 1 orientiert
https://metalab.at/wiki/images/3/36/Metalab_statuten.pdf
(Auszug aus den Statuten:
§ 1: Name, Sitz und Tätigkeitsbereich
(1) Der Verein führt den Namen „Verein zur Förderung der Erforschung und Bildung sozialer und technischer Innovationen – metalab“.

§ 2: Zweck
(1) Der Verein, dessen Tätigkeit nicht auf Gewinn gerichtet ist, bezweckt die Förderung der Allgemeinheit auf dem Gebiet von Kunst, Wissenschaft und Forschung.)
